### PR TITLE
Make birth-weight binning tolerant of missing values

### DIFF
--- a/R/scales.R
+++ b/R/scales.R
@@ -12,15 +12,16 @@ bw50 <- function(x, as_factor = TRUE) {
   if(!as_factor)
     return(m)
 
-  if(length(x) < 1)
-    return(factor())
+  # No finite midpoints (empty or all-NA input) — seq() below needs a finite range.
+  if(!any(is.finite(m)))
+    return(ordered(m))
 
   lb <- m-25
   ub <- m+24
   ordered(
     m,
-    levels = seq(min(m), max(m), 50),
-    labels = paste0(format(seq(min(lb), max(lb), 50))," g - ",format(seq(min(ub), max(ub), 50))," g"))
+    levels = seq(min(m, na.rm = TRUE), max(m, na.rm = TRUE), 50),
+    labels = paste0(format(seq(min(lb, na.rm = TRUE), max(lb, na.rm = TRUE), 50))," g - ",format(seq(min(ub, na.rm = TRUE), max(ub, na.rm = TRUE), 50))," g"))
 }
 
 bw125 <- function(x, as_factor = TRUE) {
@@ -28,15 +29,16 @@ bw125 <- function(x, as_factor = TRUE) {
   if(!as_factor)
     return(m)
 
-  if(length(x) < 1)
-    return(factor())
+  # No finite midpoints (empty or all-NA input) — seq() below needs a finite range.
+  if(!any(is.finite(m)))
+    return(ordered(m))
 
   lb <- m-62
   ub <- m+62
   ordered(
     m,
-    levels = seq(min(m), max(m), 125),
-    labels = paste0(format(seq(min(lb), max(lb), 125))," g - ",format(seq(min(ub), max(ub), 125))," g"))
+    levels = seq(min(m, na.rm = TRUE), max(m, na.rm = TRUE), 125),
+    labels = paste0(format(seq(min(lb, na.rm = TRUE), max(lb, na.rm = TRUE), 125))," g - ",format(seq(min(ub, na.rm = TRUE), max(ub, na.rm = TRUE), 125))," g"))
 }
 
 bw250 <- function(x, as_factor = TRUE) {
@@ -44,15 +46,16 @@ bw250 <- function(x, as_factor = TRUE) {
   if(!as_factor)
     return(m)
 
-  if(length(x) < 1)
-    return(factor())
+  # No finite midpoints (empty or all-NA input) — seq() below needs a finite range.
+  if(!any(is.finite(m)))
+    return(ordered(m))
 
   lb <- m-125
   ub <- m+124
   ordered(
     m,
-    levels = seq(min(m), max(m), 250),
-    labels = paste0(format(seq(min(lb), max(lb), 250))," g - ",format(seq(min(ub), max(ub), 250))," g"))
+    levels = seq(min(m, na.rm = TRUE), max(m, na.rm = TRUE), 250),
+    labels = paste0(format(seq(min(lb, na.rm = TRUE), max(lb, na.rm = TRUE), 250))," g - ",format(seq(min(ub, na.rm = TRUE), max(ub, na.rm = TRUE), 250))," g"))
 }
 
 bw500 <- function(x, as_factor = TRUE) {
@@ -60,13 +63,14 @@ bw500 <- function(x, as_factor = TRUE) {
   if(!as_factor)
     return(m)
 
-  if(length(x) < 1)
-    return(factor())
+  # No finite midpoints (empty or all-NA input) — seq() below needs a finite range.
+  if(!any(is.finite(m)))
+    return(ordered(m))
 
   lb <- m-250
   ub <- m+249
   ordered(
     m,
-    levels = seq(min(m), max(m), 500),
-    labels = paste0(format(seq(min(lb), max(lb), 500))," g - ",format(seq(min(ub), max(ub), 500))," g"))
+    levels = seq(min(m, na.rm = TRUE), max(m, na.rm = TRUE), 500),
+    labels = paste0(format(seq(min(lb, na.rm = TRUE), max(lb, na.rm = TRUE), 500))," g - ",format(seq(min(ub, na.rm = TRUE), max(ub, na.rm = TRUE), 500))," g"))
 }

--- a/tests/testthat/test-scales.R
+++ b/tests/testthat/test-scales.R
@@ -1,0 +1,31 @@
+test_that("birth-weight binning tolerates missing and all-missing values", {
+  for (bin in list(neoipcr:::bw50, neoipcr:::bw125, neoipcr:::bw250, neoipcr:::bw500)) {
+    # Some values missing: every present value still bins, NA stays NA.
+    some_na <- bin(c(800, NA, 1200, 1500))
+    expect_s3_class(some_na, "ordered")
+    expect_length(some_na, 4)
+    expect_true(is.na(some_na[2]))
+
+    # All values missing: previously errored in seq() with a non-finite bound.
+    all_na <- bin(c(NA_real_, NA_real_))
+    expect_s3_class(all_na, "ordered")
+    expect_length(all_na, 2)
+    expect_true(all(is.na(all_na)))
+    expect_length(levels(all_na), 0)
+
+    # Empty input returns an empty factor.
+    expect_length(bin(numeric(0)), 0)
+
+    # as_factor = FALSE returns the numeric midpoints, preserving NA.
+    mids <- bin(c(800, NA), as_factor = FALSE)
+    expect_length(mids, 2)
+    expect_true(is.na(mids[2]))
+  }
+})
+
+test_that("bw50 groups finite weights into shared 50 g strata", {
+  # m = floor((x - 25) / 50) * 50 + 50, so 475..524 all map to the 500 g midpoint.
+  res <- neoipcr:::bw50(c(475, 500, 524, 525))
+  expect_equal(as.character(res[1]), as.character(res[3]))
+  expect_false(as.character(res[1]) == as.character(res[4]))
+})


### PR DESCRIPTION
The birth-weight binning helpers (`bw50`/`bw125`/`bw250`/`bw500`) built their factor levels from `min()`/`max()` without `na.rm`, so a single missing birth weight produced a non-finite `seq()` bound and aborted report rendering with *"'from' must be a finite number"*. Missing birth weights are normal in benchmark datasets spanning many sites, so the helpers must tolerate them.

This adds `na.rm = TRUE` to the range calls and short-circuits empty or all-missing input to an empty-levelled ordered factor, with a regression test covering the missing-value, all-missing, empty, and grouping cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
