### PR TITLE
Parse two-digit antibiotic-substance slot indices

### DIFF
--- a/R/dhis2-events.R
+++ b/R/dhis2-events.R
@@ -661,9 +661,10 @@ read_substance_days <- function(events_raw, processed_events, metadata, dataset_
       dplyr::join_by("dataElement")) |>
     dplyr::select(!"dataElement") |>
     dplyr::mutate(
+      # Substance slots are 2-digit zero-padded (AB_SUBST_01..AB_SUBST_99); capture both digits.
       index = as.integer(stringr::str_extract(
         .data$code,
-        "^NEOIPC_SURVEILLANCE_END_AB_SUBST_\\d(\\d)(_DAYS)?$", 1)),
+        "^NEOIPC_SURVEILLANCE_END_AB_SUBST_(\\d\\d)(_DAYS)?$", 1)),
       name = factor(
         dplyr::if_else(
           stringr::str_ends(.data$code, "_DAYS"),

--- a/R/schema-event-data.R
+++ b/R/schema-event-data.R
@@ -506,8 +506,8 @@ findings_cols <- with_entity_gate(
 # ---- substanceDays -------------------------------------------------------
 #
 # AB substance-days pivot from the surveillance-end DEs. Row per
-# (event_key × index), with index ∈ 1..9 extracted from
-# `NEOIPC_SURVEILLANCE_END_AB_SUBST_0<N>` and its paired `_DAYS`
+# (event_key × index), with index ∈ 1..99 extracted from
+# `NEOIPC_SURVEILLANCE_END_AB_SUBST_<NN>` and its paired `_DAYS`
 # companion.
 #
 # No separate PK — `(event_key, index)` is unique per row. Composite

--- a/tests/testthat/helper-event-data.R
+++ b/tests/testthat/helper-event-data.R
@@ -224,10 +224,13 @@ build_processed_events <- function(event_keys, event_type_key) {
 #' read_infectious_agent_findings.
 #'
 #' @param event_type_key Character scalar (or vector for multi-type).
+#' @param substance_count Integer scalar — number of antibiotic-substance slots to
+#'   materialise (DEs `NEOIPC_SURVEILLANCE_END_AB_SUBST_01..NN` + `_DAYS`). Defaults to 5L.
 #' @return A list with `$dataElements`, `$options`, `$.users_internal_map`.
 build_reader_metadata <- function(event_type_key = c("adm", "end", "bsi",
                                                       "nec", "hap", "pro",
-                                                      "ssi")) {
+                                                      "ssi"),
+                                  substance_count = 5L) {
   opts <- neoipcr::dhis2_dataset_options(
     include_event     = "full",
     include_user      = "no",
@@ -262,8 +265,8 @@ build_reader_metadata <- function(event_type_key = c("adm", "end", "bsi",
 
   # Add substance-days DEs (always associated with surveillance-end).
   if ("end" %in% event_type_key) {
-    for (i in 1:5) {
-      subst_code <- sprintf("NEOIPC_SURVEILLANCE_END_AB_SUBST_0%d", i)
+    for (i in seq_len(substance_count)) {
+      subst_code <- sprintf("NEOIPC_SURVEILLANCE_END_AB_SUBST_%02d", i)
       days_code  <- paste0(subst_code, "_DAYS")
       de_rows[[length(de_rows) + 1L]] <- list(
         dataElement = .de_uid(subst_code),
@@ -356,8 +359,9 @@ build_reader_metadata <- function(event_type_key = c("adm", "end", "bsi",
 #' Build raw events containing substance-day dataValues.
 #'
 #' @param event_keys Integer vector — one per surveillance-end event.
-#' @param substance_rows A list of lists. Each inner list maps index
-#'   (1-5) to a list with `substance_code` and optionally `days`.
+#' @param substance_rows A list of lists. Each inner list maps a 1-based slot
+#'   index (1-99, zero-padded to two digits in the emitted DE code) to a list
+#'   with `substance_code` and optionally `days`.
 #'   E.g. `list(list("1" = list(substance_code = "J01CA04", days = "3")))`.
 #'   Use `list()` for an event with no substance DEs.
 build_raw_substance_events <- function(event_keys, substance_rows) {
@@ -367,7 +371,7 @@ build_raw_substance_events <- function(event_keys, substance_rows) {
     dvs <- list()
     for (idx_str in names(row)) {
       entry <- row[[idx_str]]
-      subst_code <- sprintf("NEOIPC_SURVEILLANCE_END_AB_SUBST_0%s", idx_str)
+      subst_code <- sprintf("NEOIPC_SURVEILLANCE_END_AB_SUBST_%02d", as.integer(idx_str))
       if (!is.null(entry$substance_code)) {
         dvs[[length(dvs) + 1L]] <- list(
           dataElement = .de_uid(subst_code),

--- a/tests/testthat/test-read-event-data.R
+++ b/tests/testthat/test-read-event-data.R
@@ -301,6 +301,25 @@ test_that("gap 8: substance-days with both codes and days", {
   expect_equal(result$index[[1L]], 1L)
 })
 
+test_that("substance-days: a two-digit slot index parses to the full number, not the last digit", {
+  # Regression for the index regex AB_SUBST_\d(\d) -> AB_SUBST_(\d\d): slot 15 must read as 15, not 5.
+  opts     <- .test_opts()
+  metadata <- build_reader_metadata("end", substance_count = 15L)
+
+  events_raw <- build_raw_substance_events(
+    event_keys     = 1L,
+    substance_rows = list(list(
+      "9"  = list(substance_code = "J01CA04", days = "3"),
+      "15" = list(substance_code = "J01CR02", days = "5"))))
+  processed <- build_processed_events(1L, "end")
+
+  result <- neoipcr:::read_substance_days(events_raw, processed, metadata, opts)
+
+  expect_setequal(result$index, c(9L, 15L))
+  expect_equal(result$substance_code[result$index == 15L], "J01CR02")
+  expect_equal(result$days[result$index == 15L], 5L)
+})
+
 test_that("gap 8: substance-days zero matching events produce schema shape", {
   opts     <- .test_opts()
   expected <- neoipcr:::compile_schema(neoipcr:::substanceDays_cols, opts)


### PR DESCRIPTION
Antibiotic-substance data-element codes are zero-padded to two digits (AB_SUBST_01..AB_SUBST_99). The surveillance-end substance index regex captured only the second digit, so a slot index of 15 read as 5; capture both digits instead. Pad the reader test fixtures' slot codes the same way and let the metadata fixture build a configurable number of substance slots, with a regression test that a two-digit slot index round-trips to its full value.