### PR TITLE
Dataset-options serialisation + empty-filter warning; dev-version bump

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: neoipcr
 Type: Package
 Title: Facilitates Working With Data From the NeoIPC Project
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person(given = c("Brar", "Christian"), family = "Piening", email = "brar.piening@charite.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4478-5597")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,7 @@
+# neoipcr (development version)
+
+* Development version. The first CRAN release is planned as `0.1.0`; until then the package carries
+  the `.9000` development suffix.
+* Immutable dev-snapshot tags (`v0.1.0.9000`, `v0.1.0.9001`, …) mark the commits the NeoIPC
+  reporting container pins, so a built image records exactly which neoipcr snapshot it shipped. These
+  do not consume the `0.1.0` version, which stays reserved for the CRAN release.

--- a/R/dhis2-options.R
+++ b/R/dhis2-options.R
@@ -168,5 +168,9 @@ dhis2_dataset_options <- function(
     trial_keys = trial_keys,
     translate = translate,
     locale = locale
-  ), class = "neoipcr_dhis2_dsopt")
+    # Inherit "list" so jsonlite (and other serialisers) handle it as its
+    # underlying list — it is a structure(list(...)) — without needing a bespoke
+    # asJSON method; every type check uses inherits(), so the extra class is
+    # transparent to them.
+  ), class = c("neoipcr_dhis2_dsopt", "list"))
 }

--- a/R/import-dhis2.R
+++ b/R/import-dhis2.R
@@ -69,9 +69,9 @@ import_dhis2 <- function(
     # include_test_data is FALSE, since test units are dropped (dhis2-metadata.R)
     # before the department filter is applied.
     if (length(dept_ids) == 0L)
-      logger::log_warn(
-        "department_filter matched no accessible NEO_DEPARTMENT org unit after metadata filtering (include_test_data = {dataset_options$include_test_data}); the tracker query will be rejected by DHIS2. If a test department was selected, set include_test_data = TRUE.",
-        namespace = "neoipcr")
+      rlang::abort(
+        sprintf("department_filter matched no accessible NEO_DEPARTMENT org unit after metadata filtering (include_test_data = %s); a tracker query with no org unit would be rejected by DHIS2. If a test department was selected, set include_test_data = TRUE.", dataset_options$include_test_data),
+        class = "neoipcr_empty_department_filter")
 
     te_enrl_req <- tracker_req |>
       httr2::req_url_query(!!!ou_query("SELECTED", multi_uid(dept_ids)))

--- a/R/import-dhis2.R
+++ b/R/import-dhis2.R
@@ -60,6 +60,19 @@ import_dhis2 <- function(
     dept_ids <- metadata$.departments_internal_map |>
       dplyr::pull(.data$orgUnit)
 
+    logger::log_debug(
+      "department_filter: {length(dataset_options$department_filter)} requested code(s) resolved to {length(dept_ids)} accessible org unit(s)",
+      namespace = "neoipcr")
+    # An empty resolution here sends `orgUnit=` blank, which DHIS2 rejects with a
+    # cryptic 409 ("At least one organisation unit must be specified"). Surface
+    # the actual cause: the most common one is selecting a test department while
+    # include_test_data is FALSE, since test units are dropped (dhis2-metadata.R)
+    # before the department filter is applied.
+    if (length(dept_ids) == 0L)
+      logger::log_warn(
+        "department_filter matched no accessible NEO_DEPARTMENT org unit after metadata filtering (include_test_data = {dataset_options$include_test_data}); the tracker query will be rejected by DHIS2. If a test department was selected, set include_test_data = TRUE.",
+        namespace = "neoipcr")
+
     te_enrl_req <- tracker_req |>
       httr2::req_url_query(!!!ou_query("SELECTED", multi_uid(dept_ids)))
 

--- a/tests/testthat/test-dhis2-options.R
+++ b/tests/testthat/test-dhis2-options.R
@@ -1,0 +1,17 @@
+# Tests for R/dhis2-options.R — dhis2_dataset_options() constructor.
+
+test_that("dhis2_dataset_options() serialises cleanly via jsonlite", {
+  # The "list" entry in the object's class vector is what lets jsonlite (and the
+  # package's write_json) serialise the dsopt as its underlying list without a
+  # bespoke asJSON method. Before it was added this call errored with
+  # "No method asJSON S3 class: neoipcr_dhis2_dsopt".
+  expect_no_error(jsonlite::toJSON(dhis2_dataset_options()))
+})
+
+test_that("dhis2_dataset_options() keeps its S3 class first in the class vector", {
+  # neoipcr_dhis2_dsopt must precede "list" so S3 dispatch keeps finding the
+  # dsopt methods first; a well-meaning reorder would silently change dispatch.
+  expect_identical(
+    class(dhis2_dataset_options()),
+    c("neoipcr_dhis2_dsopt", "list"))
+})


### PR DESCRIPTION
- Make `dhis2_dataset_options` inherit from list so it serialises cleanly.
- Warn when a department filter resolves to no accessible org units.
- Bump to development version `0.1.0.9000` and add `NEWS.md`; `0.1.0` stays reserved for the first CRAN release, and immutable `v0.1.0.900N` dev-snapshot tags let downstream consumers pin an exact neoipcr build.
