### PR TITLE
Add tag-triggered release workflow; move dev version to 0.0.0.9000

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,6 +3,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Callable by the release workflow so a tagged release runs the exact same matrix as push/PR.
+  workflow_call:
 
 name: R-CMD-check
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+# Tag-triggered release for neoipcr dev-snapshot tags (e.g. v0.0.0.9000). neoipcr ships no built asset —
+# the bare, verified tag is what downstream consumes (Surveillance-Toolkit's reports- release check via
+# `git ls-remote`; the NeoIPC-Reporting image installs it via pak). Two cheap gates fail fast, then the FULL
+# R-CMD-check matrix runs (reused, not copied), then a GitHub Release is created (dev snapshots are
+# pre-releases; a future 3-component X.Y.Z CRAN tag would be a full release).
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write            # the publish job creates the GitHub Release
+
+jobs:
+  verify:
+    name: Verify tag + monotonic version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0     # full tag history for the monotonic check
+      - name: Verify tag matches DESCRIPTION Version
+        shell: bash
+        run: |
+          tag="$GITHUB_REF_NAME"; want="${tag#v}"
+          # R package versions are numeric-only (e.g. 0.0.0.9000 dev / 0.1.0 release); v0.1.0 is reserved for
+          # the first CRAN release. A '-alpha'-style suffix is invalid in R and would just fail this check.
+          desc="$(sed -n 's/^Version:[[:space:]]*//p' DESCRIPTION | tr -d '[:space:]')"
+          if [ "$want" != "$desc" ]; then
+            echo "::error::Tag '$tag' (version '$want') does not match DESCRIPTION Version '$desc'. Bump DESCRIPTION or retag."
+            exit 1
+          fi
+          echo "Release version matches DESCRIPTION ($desc)."
+      - name: Enforce monotonic version (per-line, semver-correct)
+        shell: bash
+        run: |
+          tag="$GITHUB_REF_NAME"; ver="${tag#v}"
+          line="$(cut -d. -f1-2 <<<"$ver")."                       # major.minor + '.'  (trailing dot: 1.1. != 1.10.)
+          mapfile -t vers < <(git tag -l 'v*' | sed 's/^v//')
+          if printf '%s\n' "${vers[@]}" | grep -qxF "$ver"; then
+            echo "::error::Release tag '$tag' already exists."; exit 1
+          fi
+          # Semver precedence: map the pre-release '-' -> '~' before `sort -V` (its tilde rule sorts a
+          # pre-release BEFORE its release), then restore. neoipcr versions are numeric-only, so this is a
+          # no-op here, but keeps one implementation shared across all repos' release guards.
+          same="$(printf '%s\n' "${vers[@]}" | grep -E "^${line//./\\.}" | sed 's/-/~/' | sort -V | sed 's/~/-/' | tail -1 || true)"
+          if [ -n "$same" ]; then
+            hi="$(printf '%s\n%s\n' "$same" "$ver" | sed 's/-/~/' | sort -V | sed 's/~/-/' | tail -1)"
+            if [ "$hi" != "$ver" ]; then
+              echo "::error::Release '$ver' is not greater than the last released '$same' on the ${line%.} line."
+              exit 1
+            fi
+            echo "Monotonic OK: $ver > $same (line ${line%.})."
+          else
+            echo "Monotonic OK: new ${line%.} line."
+          fi
+
+  check:
+    name: R CMD check
+    needs: verify
+    # Reuse the exact matrix the push/PR CI runs (ubuntu release+devel, windows, macos) so a released tag is
+    # verified identically. R-CMD-check.yaml declares `on: workflow_call`.
+    uses: ./.github/workflows/R-CMD-check.yaml
+
+  publish:
+    name: Create GitHub Release
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create the Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # A 4-component dev snapshot (X.Y.Z.NNNN) is a pre-release; a 3-component X.Y.Z (future CRAN) is final.
+        shell: bash
+        run: |
+          tag="$GITHUB_REF_NAME"
+          pre=""
+          if [ "$(IFS=.; set -- ${tag#v}; echo $#)" -ge 4 ]; then pre="--prerelease"; fi
+          gh release create "$tag" --generate-notes $pre

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # Tag-triggered release for neoipcr dev-snapshot tags (e.g. v0.0.0.9000). neoipcr ships no built asset —
-# the bare, verified tag is what downstream consumes (Surveillance-Toolkit's reports- release check via
+# the bare, verified tag is what downstream consumes (Surveillance-Toolkit's `reports-v*` release check via
 # `git ls-remote`; the NeoIPC-Reporting image installs it via pak). Two cheap gates fail fast, then the FULL
 # R-CMD-check matrix runs (reused, not copied), then a GitHub Release is created (dev snapshots are
 # pre-releases; a future 3-component X.Y.Z CRAN tag would be a full release).
@@ -32,15 +32,23 @@ jobs:
             exit 1
           fi
           echo "Release version matches DESCRIPTION ($desc)."
+      - name: Reject a moved / retagged release tag
+        # A tag push with created=false means an existing tag was force-moved. Releases are immutable --
+        # cut a new version rather than re-pointing a tag. This replaces a duplicate-name check: a newly
+        # created tag can never already exist, and `checkout` (fetch-depth: 0) includes the triggering tag.
+        if: github.event.created != true
+        shell: bash
+        run: |
+          echo "::error::Tag '$GITHUB_REF_NAME' already existed and was moved; releases are immutable. Cut a new version instead."
+          exit 1
       - name: Enforce monotonic version (per-line, semver-correct)
         shell: bash
         run: |
           tag="$GITHUB_REF_NAME"; ver="${tag#v}"
           line="$(cut -d. -f1-2 <<<"$ver")."                       # major.minor + '.'  (trailing dot: 1.1. != 1.10.)
-          mapfile -t vers < <(git tag -l 'v*' | sed 's/^v//')
-          if printf '%s\n' "${vers[@]}" | grep -qxF "$ver"; then
-            echo "::error::Release tag '$tag' already exists."; exit 1
-          fi
+          # fetch-depth: 0 includes the triggering tag; exclude it so the comparison uses the genuinely
+          # previous tag on this line, not this release itself.
+          mapfile -t vers < <(git tag -l 'v*' | sed 's/^v//' | grep -vxF "$ver" || true)
           # Semver precedence: map the pre-release '-' -> '~' before `sort -V` (its tilde rule sorts a
           # pre-release BEFORE its release), then restore. neoipcr versions are numeric-only, so this is a
           # no-op here, but keeps one implementation shared across all repos' release guards.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: neoipcr
 Type: Package
 Title: Facilitates Working With Data From the NeoIPC Project
-Version: 0.1.0.9000
+Version: 0.0.0.9000
 Authors@R: c(
     person(given = c("Brar", "Christian"), family = "Piening", email = "brar.piening@charite.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-4478-5597")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,6 @@
 
 * Development version. The first CRAN release is planned as `0.1.0`; until then the package carries
   the `.9000` development suffix.
-* Immutable dev-snapshot tags (`v0.1.0.9000`, `v0.1.0.9001`, …) mark the commits the NeoIPC
+* Immutable dev-snapshot tags (`v0.0.0.9000`, `v0.0.0.9001`, …) mark the commits the NeoIPC
   reporting container pins, so a built image records exactly which neoipcr snapshot it shipped. These
   do not consume the `0.1.0` version, which stays reserved for the CRAN release.


### PR DESCRIPTION
## What

Adds a tag-triggered release workflow and aligns the development version with the R-canonical scheme.

### Release workflow (`.github/workflows/release.yml`)

On a pushed `v*` tag:

1. **verify** — the tag equals `DESCRIPTION` `Version:`, and a per-line, semver-correct monotonic guard rejects a duplicate tag or a within-line version regression. A new `major.minor` line, and backports on older lines, are allowed. The comparator maps a pre-release `-` to `~` before `sort -V` so pre-release precedence is honoured (a future final `0.1.0` is not blocked by a `0.1.0-…` pre-release).
2. **check** — the full `R-CMD-check` matrix (ubuntu release+devel, windows, macos), reused via `workflow_call` so a released tag runs exactly what push/PR runs, not a reduced copy.
3. **publish** — creates a GitHub Release with generated notes (dev snapshots are marked pre-release).

`R-CMD-check.yaml` gains an `on: workflow_call` trigger so it can be reused by the release workflow.

### Development version → `0.0.0.9000`

Sets `DESCRIPTION` to the R-canonical pre-first-release dev version `0.0.0.9000` (so `0.0.0.9000 < 0.1.0`); `v0.1.0` stays reserved for the first CRAN release. The NEWS dev-snapshot tag examples are updated to match.
