### PR TITLE
Make the release job idempotent on re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,4 +86,6 @@ jobs:
           tag="$GITHUB_REF_NAME"
           pre=""
           if [ "$(IFS=.; set -- ${tag#v}; echo $#)" -ge 4 ]; then pre="--prerelease"; fi
-          gh release create "$tag" --generate-notes $pre
+          # Idempotent: an Actions re-run reuses the original push payload, so skip if the Release already
+          # exists (a prior run may have created it). No asset is attached, so nothing to re-do on the skip.
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --generate-notes $pre


### PR DESCRIPTION
Follow-up to #16: make the release job recoverable on an Actions re-run.

`gh release create` has no guard for an already-existing Release, so a re-run after a transient failure would hard-fail. A re-run reuses the original push payload (`created` stays `true`), so the retag guard does not protect against it. Guard the create with a `gh release view … || gh release create` existence check. The dev-snapshot Release attaches no asset, so nothing needs re-doing on the skip path.
