### PR TITLE
Handle missing optional patient attributes in reference figures

### DIFF
--- a/R/calc-tables.R
+++ b/R/calc-tables.R
@@ -1,9 +1,14 @@
 get_birthweight_figure_data <- function(x) {
-  bw_quartiles <- x$patients$birth_weight |>
+  # Birth weight is an optional attribute (mandatory = false); the
+  # distribution figure covers only patients with a recorded value.
+  birth_weight <- x$patients$birth_weight
+  birth_weight <- birth_weight[!is.na(birth_weight)]
+
+  bw_quartiles <- birth_weight |>
     stats::quantile(names = FALSE) |>
     as.integer()
 
-  bw_mean = x$patients$birth_weight |>
+  bw_mean = birth_weight |>
     mean() |>
     as.integer()
 
@@ -11,8 +16,8 @@ get_birthweight_figure_data <- function(x) {
   bw_scale_max <- as.integer(bw_quartiles[5] / 50L) * 50L + 100L
 
   # density.default needs at least two points
-  if (length(x$patients$birth_weight) > 1) {
-    bw_density <- x$patients$birth_weight |>
+  if (length(birth_weight) > 1) {
+    bw_density <- birth_weight |>
       stats::density(from = bw_scale_min, to = bw_scale_max)
 
     density_bw <- bw_density$x
@@ -28,7 +33,7 @@ get_birthweight_figure_data <- function(x) {
       density = density_val
     ),
     frequency = tibble::tibble(
-      birth_weight_cat = x$patients$birth_weight |>
+      birth_weight_cat = birth_weight |>
         bw50(as_factor = F)
     ) |>
       dplyr::group_by(.data$birth_weight_cat) |>
@@ -46,11 +51,18 @@ get_birthweight_figure_data <- function(x) {
 }
 
 get_gestational_age_figure_data <- function(x) {
-  ga_quartiles <- x$patients$total_gestation_days |>
+  # Gestational age is an optional attribute (mandatory = false); the
+  # distribution figure covers only patients with a recorded value. A
+  # program rule guarantees birth weight or gestational age is present,
+  # but either one alone can be missing.
+  total_gestation_days <- x$patients$total_gestation_days
+  total_gestation_days <- total_gestation_days[!is.na(total_gestation_days)]
+
+  ga_quartiles <- total_gestation_days |>
     stats::quantile(names = FALSE) |>
     as.integer()
 
-  ga_mean = x$patients$total_gestation_days |>
+  ga_mean = total_gestation_days |>
     mean() |>
     as.integer()
 
@@ -58,8 +70,8 @@ get_gestational_age_figure_data <- function(x) {
   ga_scale_max = as.integer(ga_quartiles[5] / 7L) * 7L + 14L
 
   # density.default needs at least two points
-  if (length(x$patients$total_gestation_days) > 1) {
-    ga_density <- x$patients$total_gestation_days |>
+  if (length(total_gestation_days) > 1) {
+    ga_density <- total_gestation_days |>
       stats::density(from = ga_scale_min, to = ga_scale_max)
 
     density_ga <- ga_density$x
@@ -75,7 +87,7 @@ get_gestational_age_figure_data <- function(x) {
       density = density_val
     ),
     frequency = tibble::tibble(
-      gestational_age_cat = x$patients$total_gestation_days |>
+      gestational_age_cat = total_gestation_days |>
         ga7()
     ) |>
       dplyr::group_by(.data$gestational_age_cat) |>

--- a/R/validation-rules-surveillance-end.R
+++ b/R/validation-rules-surveillance-end.R
@@ -1,5 +1,9 @@
-# Find surveillance end events where the stored number of patient days does not
-# match the value calculated from the enrolment date and the event date.
+# Find surveillance end events where the stored number of patient days is
+# missing, or does not match the value calculated from the enrolment date and
+# the event date. patient_days is compulsory in DHIS2 and calculated from those
+# dates, so a missing value is a data-quality failure and is flagged like a
+# mismatch. The `is.na()` guard is required because `NA != x` is NA, which
+# `filter()` drops — so without it a missing value would slip past validation.
 validation_rule_18 <- function(x, exceptions)
 {
   check_neoipcr_ds(x)
@@ -21,7 +25,9 @@ validation_rule_18 <- function(x, exceptions)
       dplyr::mutate(
         patient_days_calculated = 1L + as.integer(.data$occurredAt - .data$enrolledAt)
       ) |>
-      dplyr::filter(.data$patient_days_calculated != .data$patient_days) |>
+      dplyr::filter(
+        is.na(.data$patient_days) |
+          .data$patient_days_calculated != .data$patient_days) |>
       dplyr::select(
         tidyselect::any_of(
           c("hospital_key",

--- a/tests/testthat/test-calc-tables.R
+++ b/tests/testthat/test-calc-tables.R
@@ -249,6 +249,26 @@ test_that("get_gestational_age_figure_data location parameters match fixture", {
   expect_equal(lp$q3, as.integer(q[4]))
 })
 
+test_that("figure builders drop NA optional attributes", {
+  # birth_weight and gestational age are optional TEAs (mandatory = false);
+  # a patient can be missing either one. The distribution figures cover only
+  # recorded values, so an NA must be excluded, not crash the quantile.
+  ds <- make_calc_test_ds()
+  ds$patients$birth_weight[1]         <- NA_integer_
+  ds$patients$total_gestation_days[2] <- NA_integer_
+
+  present_bw <- ds$patients$birth_weight[!is.na(ds$patients$birth_weight)]
+  bw <- neoipcr:::get_birthweight_figure_data(ds)$location_parameters
+  expect_equal(bw$mean, as.integer(mean(present_bw)))
+  expect_equal(bw$q2, as.integer(quantile(present_bw, names = FALSE)[3]))
+
+  present_ga <- ds$patients$total_gestation_days[
+    !is.na(ds$patients$total_gestation_days)]
+  ga <- neoipcr:::get_gestational_age_figure_data(ds)$location_parameters
+  expect_equal(ga$mean, as.integer(mean(present_ga)))
+  expect_equal(ga$q2, as.integer(quantile(present_ga, names = FALSE)[3]))
+})
+
 # --- Empty-data resilience ---
 
 empty_ds <- make_empty_calc_test_ds()

--- a/tests/testthat/test-validation-rules-surveillance-end.R
+++ b/tests/testthat/test-validation-rules-surveillance-end.R
@@ -42,6 +42,29 @@ test_that("rule 18 returns no rows when patient_days is correct", {
   expect_equal(nrow(result), 0L)
 })
 
+test_that("rule 18 detects missing (NA) patient_days", {
+  # patient_days is compulsory + auto-calculated in DHIS2; a missing value
+  # bypassed that calculation and must be flagged. Without the is.na() guard
+  # the `NA != calculated` comparison is NA and filter() would drop it.
+  ds <- make_test_ds(
+    patients    = make_test_patients(1),
+    enrollments = make_test_enrollments(1,
+      patient_keys = 1L,
+      enrolledAt = as.Date("2024-01-01")),
+    events = make_test_events(2,
+      enrollment_keys = c(1L, 1L),
+      patient_keys    = c(1L, 1L),
+      event_type_keys = c("adm", "end"),
+      occurredAt = as.Date(c("2024-01-01", "2024-01-11"))),
+    surveillanceEndData = make_test_surveillance_end_data(
+      event_keys = 2L,
+      patient_days = NA_integer_))
+  result <- neoipcr:::validation_rule_18(ds, NULL)
+  expect_equal(nrow(result), 1L)
+  expect_equal(unique(result$rule_id), 18L)
+  expect_true(1L %in% result$patient_key)
+})
+
 test_that("rule 18 honours exceptions", {
   ds <- make_test_ds(
     patients    = make_test_patients(1),


### PR DESCRIPTION
Birth weight and gestational age are optional patient attributes (a program rule guarantees one is present, but either can be absent). The reference-report distribution-figure builders computed quantiles/mean/density over the raw column, so a single missing value aborted `calculate_reference_data()` with a `quantile()` "missing values not allowed" error. They now drop NA first, so a missing value is excluded from the distribution rather than crashing the report.

Validation rule 18 additionally flags a missing (NA) `patient_days` — a compulsory, program-rule-calculated field whose absence is a data-quality failure — alongside the existing calculated-value mismatch check.

Covered by new regression tests in `test-calc-tables.R` and `test-validation-rules-surveillance-end.R`.