### PR TITLE
Fail the text-file hygiene check when it inspects nothing

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,7 +82,11 @@ jobs:
           # indistinguishable from a healthy checkout, on exactly the defect it exists to catch.
           $checked = @($rows | Where-Object { -not $_.IsBinary })
           if ($checked.Count -eq 0) {
-            Write-Output '::error::Cannot check text-file hygiene: no tracked text files found, so nothing was inspected.'
+            # Two states reach here and they need different fixes, so the message must not name only one:
+            # the repository tracks nothing at all, or it tracks files and git reports every one of them
+            # binary — which a .gitattributes regression produces, and which is the more likely and the
+            # more misleading, since the checkout looks entirely normal.
+            Write-Output '::error::Cannot check text-file hygiene: nothing was inspected. Either no paths are tracked, or git reports every tracked path as binary — check .gitattributes before assuming the checkout is empty.'
             exit 1
           }
           Write-Output "Text-file hygiene OK: $($checked.Count) file(s)."

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -77,7 +77,15 @@ jobs:
             Write-Output "Expected LF line endings and UTF-8 without a BOM. See .gitattributes and .editorconfig."
             exit 1
           }
-          Write-Output "Text-file hygiene OK: $(@($rows | Where-Object { -not $_.IsBinary }).Count) file(s)."
+          # A run that inspected nothing must not report success. With no rows, every check above passes
+          # vacuously, so this job would print OK and exit 0 having looked at nothing — a result
+          # indistinguishable from a healthy checkout, on exactly the defect it exists to catch.
+          $checked = @($rows | Where-Object { -not $_.IsBinary })
+          if ($checked.Count -eq 0) {
+            Write-Output '::error::Cannot check text-file hygiene: no tracked text files found, so nothing was inspected.'
+            exit 1
+          }
+          Write-Output "Text-file hygiene OK: $($checked.Count) file(s)."
 
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
With no files to examine every assertion passed vacuously, so the job reported success having looked at nothing — indistinguishable from a healthy checkout, on exactly the defect it exists to catch.